### PR TITLE
Add `--depth=1` to `git clone`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -260,7 +260,7 @@ check_software() {
 
   if [[ "$_AUTO" -eq "1" ]]; then
       if ! type "$1" >/dev/null 2>&1; then
-            git clone https://github.com/m0zgen/$2.git $_DESTINATION/$2
+            git clone --depth=1 https://github.com/m0zgen/$2.git $_DESTINATION/$2
             $_DESTINATION/$2/install.sh
           else
             Info "$ON_CHECK" "$1 already installed"
@@ -269,7 +269,7 @@ check_software() {
     if confirm "Install $1? (y/n or enter)"; then
 
         if ! type "$1" >/dev/null 2>&1; then
-          git clone https://github.com/m0zgen/$2.git $_DESTINATION/$2
+          git clone --depth=1 https://github.com/m0zgen/$2.git $_DESTINATION/$2
           $_DESTINATION/$2/install.sh
         else
           Info "$ON_CHECK" "$1 already installed"


### PR DESCRIPTION
Instead of cloning the repository with all the history and branches, this saves users a few bytes of disk and network by using the shallow clone flag `--depth=1`.